### PR TITLE
MAKE-534: methods for FTDC chunks to calculate rollups/means/totals from the chunks

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -15,16 +15,16 @@ import (
 )
 
 func (c *Chunk) getFieldNames() []string {
-	fieldNames := make([]string, len(c.metrics))
-	for idx, m := range c.metrics {
+	fieldNames := make([]string, len(c.Metrics))
+	for idx, m := range c.Metrics {
 		fieldNames[idx] = m.Key()
 	}
 	return fieldNames
 }
 
 func (c *Chunk) getRecord(i int) []string {
-	fields := make([]string, len(c.metrics))
-	for idx, m := range c.metrics {
+	fields := make([]string, len(c.Metrics))
+	for idx, m := range c.Metrics {
 		switch m.originalType {
 		case bsonx.TypeDouble, bsonx.TypeInt32, bsonx.TypeInt64, bsonx.TypeBoolean, bsonx.TypeTimestamp:
 			fields[idx] = strconv.FormatInt(m.Values[i], 10)
@@ -52,7 +52,7 @@ func WriteCSV(ctx context.Context, iter *ChunkIterator, writer io.Writer) error 
 				return errors.Wrap(err, "problem writing field names")
 			}
 			numFields = len(fieldNames)
-		} else if numFields != len(chunk.metrics) {
+		} else if numFields != len(chunk.Metrics) {
 			return errors.New("unexpected schema change detected")
 		}
 
@@ -118,7 +118,7 @@ func DumpCSV(ctx context.Context, iter *ChunkIterator, prefix string) error {
 				return errors.Wrap(err, "problem writing field names")
 			}
 			numFields = len(fieldNames)
-		} else if numFields != len(chunk.metrics) {
+		} else if numFields != len(chunk.Metrics) {
 			if err = writer.Close(); err != nil {
 				return errors.Wrap(err, "problem flushing and closing file")
 			}

--- a/ftdc.go
+++ b/ftdc.go
@@ -10,15 +10,14 @@ import (
 
 // Chunk represents a 'metric chunk' of data in the FTDC.
 type Chunk struct {
-	metrics   []Metric
+	Metrics   []Metric
 	nPoints   int
 	metadata  *bsonx.Document
 	reference *bsonx.Document
 }
 
-func (c *Chunk) GetMetadata() *bsonx.Document {
-	return c.metadata
-}
+func (c *Chunk) GetMetadata() *bsonx.Document { return c.metadata }
+func (c *Chunk) GetNumPoints() int            { return c.nPoints }
 
 // Iterator returns an iterator that you can use to read documents for
 // each sample period in the chunk. Documents are returned in collection

--- a/ftdc.go
+++ b/ftdc.go
@@ -17,7 +17,8 @@ type Chunk struct {
 }
 
 func (c *Chunk) GetMetadata() *bsonx.Document { return c.metadata }
-func (c *Chunk) GetNumPoints() int            { return c.nPoints }
+func (c *Chunk) Size() int                    { return c.nPoints }
+func (c *Chunk) Len() int                     { return len(c.Metrics) }
 
 // Iterator returns an iterator that you can use to read documents for
 // each sample period in the chunk. Documents are returned in collection

--- a/ftdc_test.go
+++ b/ftdc_test.go
@@ -27,7 +27,7 @@ func init() {
 // for this chunk.
 func (c *Chunk) renderMap() map[string]Metric {
 	m := make(map[string]Metric)
-	for _, metric := range c.metrics {
+	for _, metric := range c.Metrics {
 		m[metric.Key()] = metric
 	}
 	return m
@@ -101,11 +101,11 @@ func TestReadPathIntegration(t *testing.T) {
 					c := iter.Chunk()
 					counter++
 					if num == 0 {
-						num = len(c.metrics)
+						num = len(c.Metrics)
 						require.Equal(t, test.expectedNum, num)
 					}
 
-					metric := c.metrics[rand.Intn(num)]
+					metric := c.Metrics[rand.Intn(num)]
 					if len(metric.Values) > 0 {
 						hasSeries++
 						passed := assert.Equal(t, metric.startingValue, metric.Values[0], "key=%s", metric.Key())
@@ -146,7 +146,7 @@ func TestReadPathIntegration(t *testing.T) {
 						data, err := c.export()
 						require.NoError(t, err)
 
-						assert.True(t, len(c.metrics) >= data.Len())
+						assert.True(t, len(c.Metrics) >= data.Len())
 						docIter := data.Iterator()
 						elems := 0
 						for docIter.Next() {
@@ -156,7 +156,7 @@ func TestReadPathIntegration(t *testing.T) {
 						}
 						// this is inexact
 						// because of timestamps...
-						assert.True(t, len(c.metrics) >= elems)
+						assert.True(t, len(c.Metrics) >= elems)
 						assert.Equal(t, elems, data.Len())
 					}
 				}

--- a/iterator_matrix.go
+++ b/iterator_matrix.go
@@ -13,21 +13,21 @@ import (
 
 func (c *Chunk) exportMatrix() map[string]interface{} {
 	out := make(map[string]interface{})
-	for _, m := range c.metrics {
+	for _, m := range c.Metrics {
 		out[m.Key()] = m.getSeries()
 	}
 	return out
 }
 
 func (c *Chunk) export() (*bsonx.Document, error) {
-	doc := bsonx.MakeDocument(len(c.metrics))
+	doc := bsonx.MakeDocument(len(c.Metrics))
 	sample := 0
 
 	var elem *bsonx.Element
 	var err error
 
-	for i := 0; i < len(c.metrics); i++ {
-		elem, sample, err = rehydrateMatrix(c.metrics, sample)
+	for i := 0; i < len(c.Metrics); i++ {
+		elem, sample, err = rehydrateMatrix(c.Metrics, sample)
 		if err == io.EOF {
 			break
 		}

--- a/iterator_sample.go
+++ b/iterator_sample.go
@@ -22,8 +22,8 @@ func (c *Chunk) streamFlattenedDocuments(ctx context.Context) <-chan *bsonx.Docu
 		defer close(out)
 		for i := 0; i < c.nPoints; i++ {
 
-			doc := bsonx.MakeDocument(len(c.metrics))
-			for _, m := range c.metrics {
+			doc := bsonx.MakeDocument(len(c.Metrics))
+			for _, m := range c.Metrics {
 				elem, ok := restoreFlat(m.originalType, m.Key(), m.Values[i])
 				if !ok {
 					continue
@@ -51,7 +51,7 @@ func (c *Chunk) streamDocuments(ctx context.Context) <-chan *bsonx.Document {
 		defer close(out)
 
 		for i := 0; i < c.nPoints; i++ {
-			doc, _ := restoreDocument(c.reference, i, c.metrics, 0)
+			doc, _ := restoreDocument(c.reference, i, c.Metrics, 0)
 			select {
 			case <-ctx.Done():
 				return

--- a/read.go
+++ b/read.go
@@ -130,7 +130,7 @@ func readChunks(ctx context.Context, ch <-chan *bsonx.Document, o chan<- *Chunk)
 		}
 		select {
 		case o <- &Chunk{
-			metrics:   metrics,
+			Metrics:   metrics,
 			nPoints:   ndeltas + 1, // this accounts for the reference document
 			metadata:  metadata,
 			reference: refDoc,

--- a/util_for_test.go
+++ b/util_for_test.go
@@ -113,7 +113,7 @@ func produceMockMetrics(ctx context.Context, samples int, newDoc func() *bsonx.D
 		panic("could not iterate")
 	}
 
-	metrics := iter.Chunk().metrics
+	metrics := iter.Chunk().Metrics
 	iter.Close()
 	return metrics
 }


### PR DESCRIPTION
This work is done on the FTDC side to enable access to the Metrics field and nPoints field in Chunks.