### PR TITLE
EVG-15479, EVG-15495: remove GO_BIN_PATH and fix linter PATH

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -32,7 +32,7 @@ functions:
       working_dir: gopath/src/github.com/mongodb/ftdc
       binary: make
       args: ["${make_args|}", "${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT", "RACE_DETECTOR", "TEST_TIMEOUT"]
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR", "TEST_TIMEOUT"]
       env:
         GOPATH: ${workdir}/gopath
         VENDOR_PKG: "github.com/${trigger_repo_owner}/${trigger_repo_name}"
@@ -108,7 +108,6 @@ buildvariants:
       RACE_DETECTOR: true
       DISABLE_COVERAGE: true
       TEST_TIMEOUT: 45m
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
     run_on:
       - archlinux-new-large
@@ -117,7 +116,6 @@ buildvariants:
   - name: lint
     display_name: Lint (Arch Linux)
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
     run_on:
       - archlinux-new-small
@@ -127,7 +125,6 @@ buildvariants:
     display_name: Ubuntu 18.04
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
     run_on:
       - ubuntu1804-test
@@ -137,7 +134,6 @@ buildvariants:
     display_name: macOS
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.16/bin/go
       GOROOT: /opt/golang/go1.16
     run_on:
       - macos-1014
@@ -152,6 +148,5 @@ buildvariants:
       - windows-64-vs2017-large
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /cygdrive/c/golang/go1.16/bin/go
-      GOROOT: "C:/golang/go1.16"
+      GOROOT: C:/golang/go1.16
     tasks: [ "testGroup" ]

--- a/makefile
+++ b/makefile
@@ -2,112 +2,83 @@
 name := ftdc
 buildDir := build
 packages := $(name) events hdrhist metrics util
+srcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "./scripts/*" -not -path "*\#*")
+testSrcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
 orgPath := github.com/mongodb
 projectPath := $(orgPath)/$(name)
 # end project configuration
 
-# test data downloads
-metrics.ftdc:
-	curl -LO "https://ftdc-test-files.s3.amazonaws.com/metrics.ftdc"
-perf_metrics.ftdc:
-	curl -LO "https://ftdc-test-files.s3.amazonaws.com/perf_metrics.ftdc"
-genny_metrics.ftdc:
-	curl -LO "https://ftdc-test-files.s3.amazonaws.com/genny_metrics.ftdc"
-$(buildDir)/output.ftdc.test:perf_metrics.ftdc metrics.ftdc genny_metrics.ftdc
-# end test files
-
 # start environment setup
-gobin := $(GO_BIN_PATH)
-ifeq (,$(gobin))
-	gobin := go
+gobin := go
+ifneq (,$(GOROOT))
+gobin := $(GOROOT)/bin/go
 endif
-gocache := $(abspath $(buildDir)/.cache)
-gopath := $(GOPATH)
-goroot := $(GOROOT)
+
 ifeq ($(OS),Windows_NT)
-	gocache := $(shell cygpath -m $(gocache))
-	gopath := $(shell cygpath -m $(gopath))
-	goroot := $(shell cygpath -m $(goroot))
+gobin := $(shell cygpath $(gobin))
+export GOCACHE := $(shell cygpath -m $(abspath $(buildDir)/.cache))
+export GOLANGCI_LINT_CACHE := $(shell cygpath -m $(abspath $(buildDir)/.lint-cache))
+export GOPATH := $(shell cygpath -m $(GOPATH))
+export GOROOT := $(shell cygpath -m $(goroot))
 endif
-export GOCACHE := $(gocache)
-export GOPATH := $(gopath)
-export GOROOT := $(goroot)
+
 export GO111MODULE := off
 # end environment setup
 
 # Ensure the build directory exists, since most targets require it.
 $(shell mkdir -p $(buildDir))
 
-# start dependency installation tools
-#   implementation details for being able to lazily install dependencies.
-#   this block has no project specific configuration but defines
-#   variables that project specific information depends on
-testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
-raceOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).race)
-lintTargets := $(foreach target,$(packages),lint-$(target))
-coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
-coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
-srcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -name "*_test.go" -not -path "./scripts/*" -not -path "*\#*")
-testSrcFiles := makefile $(shell find . -name "*.go" -not -path "./$(buildDir)/*" -not -path "*\#*")
-# end dependency installation tools
+.DEFAULT_GOAL := compile
 
+# start test data download targets
+metrics.ftdc:
+	curl -LO "https://ftdc-test-files.s3.amazonaws.com/metrics.ftdc"
+perf_metrics.ftdc:
+	curl -LO "https://ftdc-test-files.s3.amazonaws.com/perf_metrics.ftdc"
+genny_metrics.ftdc:
+	curl -LO "https://ftdc-test-files.s3.amazonaws.com/genny_metrics.ftdc"
+$(buildDir)/output.ftdc.test: perf_metrics.ftdc metrics.ftdc genny_metrics.ftdc
+# end test data file download targets
 
 # start lint setup targets
 lintDeps := $(buildDir)/golangci-lint $(buildDir)/run-linter
 $(buildDir)/golangci-lint:
 	@curl --retry 10 --retry-max-time 60 -sSfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
-$(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
+$(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	$(gobin) build -o $@ $<
 # end lint setup targets
 
+# start output files
+testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
+lintOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
+coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
+coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
+.PRECIOUS: $(testOutput) $(lintOutput) $(coverageOutput) $(coverageHtmlOutput)
+# end output files
 
-# userfacing targets for basic build and development operations
-build:$(srcFiles)
+# start basic development operations
+compile: $(srcFiles)
 	$(gobin) build $(subst $(name),,$(subst -,/,$(foreach pkg,$(packages),./$(pkg))))
-test:$(testOutput)
-lint:$(lintTargets)
-coverage:$(coverageOutput)
-coverage-html:$(coverageHtmlOutput)
-list-tests:
-	@echo -e "test targets:" $(foreach target,$(packages),\\n\\ttest-$(target))
-phony := lint build test coverage coverage-html
-.PRECIOUS:$(testOutput) $(raceOutput) $(coverageOutput) $(coverageHtmlOutput)
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).test)
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).race)
-.PRECIOUS:$(foreach target,$(packages),$(buildDir)/output.$(target).lint)
-# end front-ends
+test: $(testOutput)
+lint: $(lintOutput)
+coverage: $(coverageOutput)
+coverage-html: $(coverageHtmlOutput)
+phony += compile lint test coverage coverage-html
 
-
-# convenience targets for runing tests and coverage tasks on a
+# start convenience targets for running tests and coverage tasks on a
 # specific package.
-test-%:$(buildDir)/output.%.test
+test-%: $(buildDir)/output.%.test
 	@grep -s -q -e "^PASS" $<
-coverage-%:$(buildDir)/output.%.coverage
+coverage-%: $(buildDir)/output.%.coverage
 	@grep -s -q -e "^PASS" $(subst coverage,test,$<)
-html-coverage-%:$(buildDir)/output.%.coverage $(buildDir)/output.%.coverage.html
+html-coverage-%: $(buildDir)/output.%.coverage $(buildDir)/output.%.coverage.html
 	@grep -s -q -e "^PASS" $(subst coverage,test,$<)
-lint-%:$(buildDir)/output.%.lint
+lint-%: $(buildDir)/output.%.lint
 	@grep -v -s -q "^--- FAIL" $<
-# end convienence targets
-
-
-# start vendoring configuration
-vendor-clean:
-	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/stretchr/testify/
-	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/pkg/errors/
-	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*.dat" -o -name "*testdata" | xargs rm -rf
-	find vendor/ -name '.git' | xargs rm -rf
-	find vendor/ -type d -empty | xargs rm -rf
-#   add phony targets
-phony += vendor-clean
-# end vendoring tooling configuration
-
+# end convenience targets
+# end basic development operations
 
 # start test and coverage artifacts
-#    This varable includes everything that the tests actually need to
-#    run. (The "build" target is intentional and makes these targetsb
-#    rerun as expected.)
-testRunEnv := GOPATH=$(gopath)
 testArgs := -v
 ifneq (,$(RUN_TEST))
 testArgs += -run='$(RUN_TEST)'
@@ -129,29 +100,41 @@ testArgs += -timeout=$(TEST_TIMEOUT)
 else
 testArgs += -timeout=30m
 endif
-# testing targets
 $(buildDir)/output.%.test: .FORCE
-	$(testRunEnv) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
+	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) | tee $@
 $(buildDir)/output.%.coverage: $(buildDir)/ .FORCE
-	$(testRunEnv) $(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
-	@-[ -f $@ ] && $(testRunEnv) $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
-$(buildDir)/output.%.coverage.html:$(buildDir)/output.%.coverage
-	$(testRunEnv) $(gobin) tool cover -html=$< -o $@
-#  targets to generate gotest output from the linter.
-# We have to handle the PATH specially for CI, because if the PATH has a different version of Go in it, it'll break.
-$(buildDir)/output.%.lint:$(buildDir)/run-linter $(buildDir)/ .FORCE
-	@$(if $(GO_BIN_PATH), PATH="$(shell dirname $(GO_BIN_PATH)):$(PATH)") ./$< --output=$@ --lintBin="$(buildDir)/golangci-lint" --packages='$*'
+	$(gobin) test $(testArgs) ./$(if $(subst $(name),,$*),$(subst -,/,$*),) -covermode=count -coverprofile $@ | tee $(buildDir)/output.$*.test
+	@-[ -f $@ ] && $(gobin) tool cover -func=$@ | sed 's%$(projectPath)/%%' | column -t
+$(buildDir)/output.%.coverage.html: $(buildDir)/output.%.coverage
+	$(gobin) tool cover -html=$< -o $@
+
+ifneq (go,$(gobin))
+# We have to handle the PATH specially for linting in CI, because if the PATH has a different version of the Go
+# binary in it, the linter won't work properly.
+lintEnvVars := PATH="$(shell dirname $(gobin)):$(PATH)"
+endif
+$(buildDir)/output.%.lint: $(buildDir)/run-linter .FORCE
+	@$(lintEnvVars) ./$< --output=$@ --lintBin=$(buildDir)/golangci-lint --packages='$*'
 # end test and coverage artifacts
 
+# start vendoring configuration
+vendor-clean:
+	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/stretchr/testify/
+	rm -rf vendor/github.com/mongodb/grip/vendor/github.com/pkg/errors/
+	find vendor/ -name "*.gif" -o -name "*.gz" -o -name "*.png" -o -name "*.ico" -o -name "*.dat" -o -name "*testdata" | xargs rm -rf
+	find vendor/ -name '.git' | xargs rm -rf
+	find vendor/ -type d -empty | xargs rm -rf
+phony += vendor-clean
+# end vendoring configuration
 
-# clean and other utility targets
+# start cleanup targets
 clean:
-	rm -rf $(lintDeps)
+	rm -rf $(buildDir)
 clean-results:
 	rm -rf $(buildDir)/output.*
 phony += clean
-# end dependency targets
+# end cleanup targets
 
 # configure phony targets
 .FORCE:
-.PHONY:$(phony) .FORCE
+.PHONY: $(phony) .FORCE


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-15479
https://jira.mongodb.org/browse/EVG-15495

* Remove GO_BIN_PATH. CI tests now depend on GOROOT to tell them which Go version to use and which Go binary to use.
* Set the GOLANGCI_LINT_CACHE, which is used to control where golangci-lint caches information. By default, golangci-lint will use the user's cache directory (usually in the home directory). This prevents the CI linter from writing outside of the working directory.
* Fix setting the PATH variable for the linter.
* Clean up and standardize the makefile.