### PR TITLE
EVG-18021: Fix delta extraction and rehydration for floats

### DIFF
--- a/bson_extract.go
+++ b/bson_extract.go
@@ -121,7 +121,7 @@ func extractMetricsFromValue(val *birch.Value) (extractedMetrics, error) {
 func extractDelta(current *birch.Value, previous *birch.Value) (int64, error) {
 	switch current.Type() {
 	case bsontype.Double:
-		return normalizeFloat(current.Double() - previous.Double()), nil
+		return normalizeFloat(current.Double()) - normalizeFloat(previous.Double()), nil
 	case bsontype.Int64:
 		return current.Int64() - previous.Int64(), nil
 	default:

--- a/ftdc_test.go
+++ b/ftdc_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evergreen-ci/birch"
 	"github.com/mongodb/ftdc/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,13 +141,12 @@ func TestReadPathIntegration(t *testing.T) {
 							require.Equal(t, test.expectedMetrics, array.Len())
 							elems++
 						}
-						// this is inexact
-						// because of timestamps...l
+						// This is inexact because of
+						// timestamps.
 						assert.True(t, len(c.Metrics) >= elems)
 						assert.Equal(t, elems, data.Len())
 					}
 				}
-
 				assert.NoError(t, iter.Err())
 
 				assert.Equal(t, test.expectedNum, num)
@@ -288,29 +286,28 @@ func TestRoundTrip(t *testing.T) {
 				if test.numStats == 0 || (test.randStats && !strings.Contains(collect.name, "Dynamic")) {
 					continue
 				}
-				if test.name != "Floats" {
-					continue
-				}
+				/*
+					if test.name != "Floats" {
+						continue
+					}
+				*/
 				t.Run(test.name, func(t *testing.T) {
 					collector := collect.factory()
 					assert.NoError(t, collector.SetMetadata(testutil.CreateEventRecord(42, int64(time.Minute), rand.Int63n(7), 4)))
 
-					var docs []*birch.Document
 					for _, d := range test.docs {
 						assert.NoError(t, collector.Add(d))
-						docs = append(docs, d)
 					}
-
 					data, err := collector.Resolve()
 					require.NoError(t, err)
 					iter := ReadStructuredMetrics(ctx, bytes.NewBuffer(data))
 
 					docNum := 0
 					for iter.Next() {
-						require.True(t, docNum < len(docs))
+						require.True(t, docNum < len(test.docs))
 						roundtripDoc := iter.Document()
 
-						assert.Equal(t, fmt.Sprint(roundtripDoc), fmt.Sprint(docs[docNum]))
+						assert.Equal(t, fmt.Sprint(test.docs[docNum]), fmt.Sprint(roundtripDoc))
 						docNum++
 					}
 				})

--- a/ftdc_test.go
+++ b/ftdc_test.go
@@ -286,11 +286,6 @@ func TestRoundTrip(t *testing.T) {
 				if test.numStats == 0 || (test.randStats && !strings.Contains(collect.name, "Dynamic")) {
 					continue
 				}
-				/*
-					if test.name != "Floats" {
-						continue
-					}
-				*/
 				t.Run(test.name, func(t *testing.T) {
 					collector := collect.factory()
 					assert.NoError(t, collector.SetMetadata(testutil.CreateEventRecord(42, int64(time.Minute), rand.Int63n(7), 4)))

--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,5 @@ require (
 	github.com/shirou/gopsutil v3.21.9+incompatible // indirect
 	github.com/tklauser/go-sysconf v0.3.9 // indirect
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1 // indirect
+	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -294,8 +294,9 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71 h1:ikCpsnYR+Ew0vu99XlDp55lGgDJdIMx3f4a18jfse/s=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/read.go
+++ b/read.go
@@ -9,7 +9,6 @@ import (
 	"io"
 
 	"github.com/evergreen-ci/birch"
-	"github.com/evergreen-ci/birch/bsontype"
 	"github.com/pkg/errors"
 )
 
@@ -123,12 +122,7 @@ func readChunks(ctx context.Context, ch <-chan *birch.Document, o chan<- *Chunk)
 				}
 				metrics[i].Values[j] = int64(delta)
 			}
-			if metrics[i].originalType == bsontype.Double {
-				metrics[i].Values = undeltaFloats(v.startingValue, metrics[i].Values)
-			} else {
-				metrics[i].Values = undelta(v.startingValue, metrics[i].Values)
-			}
-
+			metrics[i].Values = undelta(v.startingValue, metrics[i].Values)
 		}
 		select {
 		case o <- &Chunk{

--- a/util.go
+++ b/util.go
@@ -45,13 +45,6 @@ func readDocument(in interface{}) (*birch.Document, error) {
 
 func getOffset(count, sample, metric int) int { return metric*count + sample }
 
-func undeltaFloats(value int64, deltas []int64) []int64 {
-	out := make([]int64, 1, len(deltas)+1)
-	out[0] = value
-
-	return append(out, deltas...)
-}
-
 func undelta(value int64, deltas []int64) []int64 {
 	out := make([]int64, len(deltas)+1)
 	out[0] = value


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-18021

I found two bugs here:
1. In order to comply with the FTDC spec that all metrics and deltas must be of type `int64`, we storing floats convert we convert them to their binary representation using [math.Float64bits](https://pkg.go.dev/math#Float64bits)—this returns a `uint64` that we ultimately cast to `int64` and when resolving the ftdc output. The collector code that extracts the deltas for floats was essentially doing `int64(math.Float64bits(floatValue - prevFloatValue))`. For binary representations `f(x) + f(y) != f(x+y)`, so the correct way to get the delta is `int64(math.Float64bits(floatValue) - math.Float64bits(prevFloatValue))`.
2. On the read side, when rehydrating float values we weren't actually calculating individual metrics points correctly by commencing with the starting value and adding the delta back for each subsequent point, instead we were treating the slice of deltas as the original values. 

I tested this on a round trip against a real server ftdc file and also found a round trip test that we weren't actually running. When I changed the code to run the existing round trip test it failed for the floats, the changes I made fixed that.