### PR TITLE
fix(metricForType): handle the path name correctly for embedded documents inside each other

### DIFF
--- a/bson_metric.go
+++ b/bson_metric.go
@@ -17,7 +17,6 @@ func metricForDocument(path []string, d *birch.Document) []Metric {
 
 	for iter.Next() {
 		e := iter.Element()
-
 		o = append(o, metricForType(e.Key(), path, e.Value())...)
 	}
 
@@ -52,7 +51,11 @@ func metricForType(key string, path []string, val *birch.Value) []Metric {
 		return metricForArray(key, path, val.MutableArray())
 	case bsontype.EmbeddedDocument:
 		o := []Metric{}
-		for _, ne := range metricForDocument(append(path, key), val.MutableDocument()) {
+		newPath := make([]string, len(path))
+		copy(newPath, path)
+		newPath = append(newPath, key)
+
+		for _, ne := range metricForDocument(newPath, val.MutableDocument()) {
 			o = append(o, Metric{
 				ParentPath:    ne.ParentPath,
 				KeyName:       ne.KeyName,

--- a/bson_metric.go
+++ b/bson_metric.go
@@ -17,6 +17,7 @@ func metricForDocument(path []string, d *birch.Document) []Metric {
 
 	for iter.Next() {
 		e := iter.Element()
+
 		o = append(o, metricForType(e.Key(), path, e.Value())...)
 	}
 

--- a/bson_metric.go
+++ b/bson_metric.go
@@ -51,12 +51,10 @@ func metricForType(key string, path []string, val *birch.Value) []Metric {
 	case bsontype.Array:
 		return metricForArray(key, path, val.MutableArray())
 	case bsontype.EmbeddedDocument:
-		path = append(path, key)
-
 		o := []Metric{}
-		for _, ne := range metricForDocument(path, val.MutableDocument()) {
+		for _, ne := range metricForDocument(append(path, key), val.MutableDocument()) {
 			o = append(o, Metric{
-				ParentPath:    path,
+				ParentPath:    ne.ParentPath,
 				KeyName:       ne.KeyName,
 				startingValue: ne.startingValue,
 				originalType:  ne.originalType,


### PR DESCRIPTION
This PR fixes the incorrect path resolution for embedded documents within other documents.

For example, the metric serverStatus.flowControl.isLaggedTimeMicros was previously flattened incorrectly and appeared as:
serverStatus.isLaggedTimeMicros

This change ensures that the full nested path name is preserved correctly.